### PR TITLE
Correct language tag for Catalan

### DIFF
--- a/languages.md
+++ b/languages.md
@@ -12,8 +12,8 @@ tags and because Cantonese is the main language spoken in Hong Kong,
 means any Chinese dialect localised for Hong Kong.
 
 **Catalan_Spn**.  Presumably this represents the Catalan language
-(`cn`), as spoken in Spain, though [GEDCOM] is silent on this point.
-The preferred code is therefore `cn-ES`.  Why Catalan should be singled
+(`ca`), as spoken in Spain, though [GEDCOM] is silent on this point.
+The preferred code is therefore `ca-ES`.  Why Catalan should be singled
 out as the only language to be given a regional variant is unclear, as
 Catalan is not widely spoken outside Spain.  Perhaps the GEDCOM authors
 considered Occitan (`oc`) and dialects of it such as Gascon and


### PR DESCRIPTION
https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
shows:
```
%%
Type: language
Subtag: ca
Description: Catalan
Description: Valencian
Added: 2005-10-16
Suppress-Script: Latn
%%
```

languages.tsv listed it correctly (ca)
languages.md listed it incorrectly (cn)

Signed-off-by: Dave Thaler <dthaler@armidalesoftware.com>